### PR TITLE
feat: Add streak rewards UI text and translations

### DIFF
--- a/public/locales/en/airdrop.json
+++ b/public/locales/en/airdrop.json
@@ -65,6 +65,7 @@
     "bonusXTMEarned": "Bonus XTM Earned",
     "of": "of",
     "inviteFriendsMessage": "Invite friends and start earning <strong>bonus XTM!</strong>",
+    "errorLoadingData": "Error loading crew data. Please try again.",
     "filters": {
       "all": "All",
       "complete": "Complete",
@@ -86,7 +87,14 @@
       "mineConsecutiveDays": "Mine for at least <strong>{{streakDaysRequired}} consecutive days</strong> each week to earn your bonus XTM.",
       "keepStreak": "Keep your streak to keep earning rewards!",
       "dayStreak": "{{days}} Day Streak",
-      "day": "Day"
+      "day": "Day",
+      "loadingStreak": "Loading streak...",
+      "startYourStreak": "Start Your Streak! 🚀",
+      "oneDayStreak": "1 Day Streak 🔥",
+      "multiDayStreak": "{{days}} Day Streak 🔥",
+      "startMiningMessage": "Start mining to begin your streak and earn rewards!",
+      "minimumRequirementsMet": "Great job! You've met the minimum requirements. Keep going!",
+      "daysToMinimum": "{{days}} more days to meet minimum requirements!"
     },
     "login": {
       "title": "Mine with friends. <strong>Earn together.</strong>",

--- a/src/containers/main/CrewRewards/RewardsWidget/sections/StreakProgress/StreakProgress.tsx
+++ b/src/containers/main/CrewRewards/RewardsWidget/sections/StreakProgress/StreakProgress.tsx
@@ -24,7 +24,7 @@ export default function StreakProgress({ isInline = false }: Props) {
         return (
             <Wrapper $isInline={isInline}>
                 <StreakMessage $isInline={isInline}>
-                    <Text>Loading streak...</Text>
+                    <Text>{t('airdrop:crewRewards.streak.loadingStreak')}</Text>
                     <StreakText>🔥</StreakText>
                 </StreakMessage>
             </Wrapper>
@@ -36,14 +36,14 @@ export default function StreakProgress({ isInline = false }: Props) {
     // Determine streak display
     const getStreakDisplay = () => {
         if (currentStreak === 0) {
-            return 'Start Your Streak! 🚀';
+            return t('airdrop:crewRewards.streak.startYourStreak');
         }
 
         if (currentStreak === 1) {
-            return '1 Day Streak 🔥';
+            return t('airdrop:crewRewards.streak.oneDayStreak');
         }
 
-        return `${currentStreak} Day Streak 🔥`;
+        return t('airdrop:crewRewards.streak.multiDayStreak', { days: currentStreak });
     };
 
     // Determine message based on progress
@@ -53,16 +53,16 @@ export default function StreakProgress({ isInline = false }: Props) {
         }
 
         if (currentStreak === 0) {
-            return 'Start mining to begin your streak and earn rewards!';
+            return t('airdrop:crewRewards.streak.startMiningMessage');
         }
 
         if (meetsMinimumDays) {
-            return "Great job! You've met the minimum requirements. Keep going!";
+            return t('airdrop:crewRewards.streak.minimumRequirementsMet');
         }
 
         const daysNeeded = minReferrerDaysRequired - currentStreak;
         if (daysNeeded > 0) {
-            return `${daysNeeded} more days to meet minimum requirements!`;
+            return t('airdrop:crewRewards.streak.daysToMinimum', { days: daysNeeded });
         }
 
         return t('airdrop:crewRewards.streak.keepStreak');


### PR DESCRIPTION
This commit introduces new text strings and translations related to the streak rewards feature in the crew rewards section. It adds messages for loading state, starting a streak, displaying the current streak, and indicating progress towards meeting minimum requirements. These additions enhance the user experience by providing clear and informative feedback about their streak progress.

Description
---

Motivation and Context
---

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
