### PR TITLE
feat: Display crew member images in StatsRow

### DIFF
--- a/src/containers/main/CrewRewards/RewardsWidget/sections/MainSection/segments/StatsRow/StatsRow.tsx
+++ b/src/containers/main/CrewRewards/RewardsWidget/sections/MainSection/segments/StatsRow/StatsRow.tsx
@@ -54,9 +54,14 @@ export default function StatsRow() {
             {hasFriends ? (
                 <ActiveMinersWrapper>
                     <PhotoWrapper>
-                        <PhotoImage $image={photo1} aria-hidden="true" />
-                        <PhotoImage $image={photo1} aria-hidden="true" />
-                        <PhotoImage $image={photo1} aria-hidden="true" />
+                        {crewData?.members
+                            .slice(0, 3)
+                            .map(
+                                (member) =>
+                                    member.user?.image && (
+                                        <PhotoImage $image={member.user?.image} aria-hidden="true" key={member.id} />
+                                    )
+                            )}
                         <StatusDot />
                     </PhotoWrapper>
 


### PR DESCRIPTION
The StatsRow component now displays the images of the first three members of the crew, instead of placeholder images. This provides a more personalized and engaging experience for the user by showcasing their actual crew members. A key is added to the PhotoImage component to prevent React errors.

Description
---

Motivation and Context
---

How Has This Been Tested?
---

What process can a PR reviewer use to test or verify this change?
---

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
